### PR TITLE
Format exceptions -- fix #11

### DIFF
--- a/src/GitHubActions.jl
+++ b/src/GitHubActions.jl
@@ -224,7 +224,7 @@ function Logging.handle_message(
     file, line = something(location, (file, line))
     message = string(msg)
     for (k, v) in kwargs
-        message *= "\n  $k = $v"
+        message *= "\n  $k = " * sprint(Logging.showvalue, v)
     end
     if level === Info
         println(message)

--- a/src/GitHubActions.jl
+++ b/src/GitHubActions.jl
@@ -41,7 +41,7 @@ cmd_value(::Nothing) = ""
 cmd_value(s::AbstractString) = s
 cmd_value(x) = json(x)
 
-function esc_prop(val)
+function esc_data(val)
     s = cmd_value(val)
     s = replace(s, '%' => "%25")
     s = replace(s, '\r' => "%0D")
@@ -49,7 +49,7 @@ function esc_prop(val)
     return s
 end
 
-function esc_data(val)
+function esc_prop(val)
     s = cmd_value(val)
     s = replace(s, '%' => "%25")
     s = replace(s, '\r' => "%0D")

--- a/src/GitHubActions.jl
+++ b/src/GitHubActions.jl
@@ -226,7 +226,7 @@ function Logging.handle_message(
     for (k, v) in kwargs
         result = sprint(Logging.showvalue, v)
         message *= "\n  $k = " * if occursin('\n', result)
-            "\n" * replace(result, '\n' => "\n    ")
+            replace("\n" * result, '\n' => "\n    ")
         else
             result
         end

--- a/src/GitHubActions.jl
+++ b/src/GitHubActions.jl
@@ -226,7 +226,7 @@ function Logging.handle_message(
     for (k, v) in kwargs
         result = sprint(Logging.showvalue, v)
         message *= "\n  $k = " * if occursin('\n', result)
-            "\n" * replace(result, '\n' => "    \n")
+            "\n" * replace(result, '\n' => "\n    ")
         else
             result
         end

--- a/src/GitHubActions.jl
+++ b/src/GitHubActions.jl
@@ -224,7 +224,12 @@ function Logging.handle_message(
     file, line = something(location, (file, line))
     message = string(msg)
     for (k, v) in kwargs
-        message *= "\n  $k = " * sprint(Logging.showvalue, v)
+        result = sprint(Logging.showvalue, v)
+        message *= "\n  $k = " * if occursin('\n', result)
+            "\n" * replace(result, '\n' => "    \n")
+        else
+            result
+        end
     end
     if level === Info
         println(message)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,7 +91,7 @@ const GHA = GitHubActions
         @test match(rx("error"), (@capture_out @error "a")) !== nothing
         @test (@capture_out @info "a") == "a\n"
 
-        @test (@capture_out @info "a" b=1 c=2) == "a\n  b = 1\n  c = 2\n"
+        @test (@capture_out @info "a" b=1 c=2 d=Text("e\nf")) == "a\n  b = 1\n  c = 2\n  d = \n    e\n    f\n"
         @test endswith((@capture_out @warn "a" b=1 c=2), "::a%0A  b = 1%0A  c = 2\n")
 
         expected = "::warning file=bar,line=1::foo\n"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,7 @@ const GHA = GitHubActions
     @test (@capture_out GHA.command("a", (b=1,), "")) == "::a b=1::\n"
     @test (@capture_out GHA.command("a", (b=1, c=2), "")) == "::a b=1,c=2::\n"
     @test (@capture_out GHA.command("a", (b="c%d\re\nf",), "")) == "::a b=c%25d%0De%0Af::\n"
-    @test (@capture_out GHA.command("a", (), "a%b\rc\nd:e,f")) == "::a::a%25b%0Dc%0Ad%3Ae%2Cf\n"
+    @test (@capture_out GHA.command("a", (), "a%b\rc\nd:e,f")) == "::a::a%25b%0Dc%0Ad:e,f\n"
 
     @test (@capture_out end_group()) == "::endgroup::\n"
 


### PR DESCRIPTION
Closes #11 

I believe that Julia's default logger formats log arguments using this function: https://github.com/JuliaLang/julia/blob/5c6e21edbfd8f0c7d16ea01c91d1c75c30d4eaa1/stdlib/Logging/src/ConsoleLogger.jl#L45-L51

Before:



<img width="891" alt="image" src="https://user-images.githubusercontent.com/6933510/103821146-e646f780-506d-11eb-8d82-795c1c3b3fb9.png">


After:

<img width="891" alt="image" src="https://user-images.githubusercontent.com/6933510/103827521-7e96a980-5079-11eb-9260-96675ef95fcd.png">
