### PR TITLE
Logger: Use a relative path to the workspace instead of an absolute path for `file`

### DIFF
--- a/src/GitHubActions.jl
+++ b/src/GitHubActions.jl
@@ -222,8 +222,10 @@ function Logging.handle_message(
     location=nothing, kwargs...,
 )
     file, line = something(location, (file, line))
+    
     workspace = get(ENV, "GITHUB_WORKSPACE", nothing)
     if workspace !== nothing
+        # In order for inline annotations to work correctly:
         file = relpath(file, workspace)
     end
     message = string(msg)

--- a/src/GitHubActions.jl
+++ b/src/GitHubActions.jl
@@ -241,8 +241,6 @@ function Logging.handle_message(
         elseif level === Error
             "error"
         end
-        # https://github.community/t/github-actions-error-reporting-as-annotation/17961/2
-        message = replace(message, "\n" => "%0A")
         command(cmd, (file=file, line=line), message)
     end
 end

--- a/src/GitHubActions.jl
+++ b/src/GitHubActions.jl
@@ -221,12 +221,11 @@ function Logging.handle_message(
     level, msg, _module, group, id, file, line;
     location=nothing, kwargs...,
 )
-    # file, line = something(location, (file, line))
+    file, line = something(location, (file, line))
     file = relpath(file, ENV["GITHUB_WORKSPACE"])
-    println("Logging (debug): file=$file line=$line")
     message = string(msg)
     for (k, v) in kwargs
-        result = sprint(Logging.showvalue, v; context=IOContext(stdout))
+        result = sprint(Logging.showvalue, v)
         message *= "\n  $k = " * if occursin('\n', result)
             replace("\n" * result, '\n' => "\n    ")
         else

--- a/src/GitHubActions.jl
+++ b/src/GitHubActions.jl
@@ -224,7 +224,7 @@ function Logging.handle_message(
     file, line = something(location, (file, line))
     message = string(msg)
     for (k, v) in kwargs
-        result = sprint(Logging.showvalue, v)
+        result = sprint(Logging.showvalue, v; context=IOContext(stdout))
         message *= "\n  $k = " * if occursin('\n', result)
             replace("\n" * result, '\n' => "\n    ")
         else
@@ -241,6 +241,8 @@ function Logging.handle_message(
         elseif level === Error
             "error"
         end
+        # https://github.community/t/github-actions-error-reporting-as-annotation/17961/2
+        message = replace(message, "\n" => "%0A")
         command(cmd, (file=file, line=line), message)
     end
 end

--- a/src/GitHubActions.jl
+++ b/src/GitHubActions.jl
@@ -221,7 +221,9 @@ function Logging.handle_message(
     level, msg, _module, group, id, file, line;
     location=nothing, kwargs...,
 )
-    file, line = something(location, (file, line))
+    # file, line = something(location, (file, line))
+    file = relpath(file, ENV["GITHUB_WORKSPACE"])
+    println("Logging (debug): file=$file line=$line")
     message = string(msg)
     for (k, v) in kwargs
         result = sprint(Logging.showvalue, v; context=IOContext(stdout))

--- a/src/GitHubActions.jl
+++ b/src/GitHubActions.jl
@@ -222,7 +222,10 @@ function Logging.handle_message(
     location=nothing, kwargs...,
 )
     file, line = something(location, (file, line))
-    file = relpath(file, ENV["GITHUB_WORKSPACE"])
+    workspace = get(ENV, "GITHUB_WORKSPACE", nothing)
+    if workspace !== nothing
+        file = relpath(file, workspace)
+    end
     message = string(msg)
     for (k, v) in kwargs
         result = sprint(Logging.showvalue, v)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,7 +92,7 @@ const GHA = GitHubActions
         end
         return Regex("^::$level file=$(file),line=\\d+::a")
     end
-    
+
     with_logger(GitHubActionsLogger()) do
         @test match(rx("debug"), (@capture_out @debug "a")) !== nothing
         @test match(rx("warning"), (@capture_out @warn "a")) !== nothing
@@ -102,7 +102,7 @@ const GHA = GitHubActions
         @test (@capture_out @info "a" b=1 c=2 d=Text("e\nf")) == "a\n  b = 1\n  c = 2\n  d = \n    e\n    f\n"
         @test endswith((@capture_out @warn "a" b=1 c=2), "::a%0A  b = 1%0A  c = 2\n")
 
-        expected = "::warning file=bar,line=1::foo\n"
+        expected = "::warning file=test/bar,line=1::foo\n"
         @test (@capture_out @warn "foo" location=("bar", 1)) == expected
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,7 +84,15 @@ const GHA = GitHubActions
         end
     end
 
-    rx(level) = Regex("^::$level file=$(@__FILE__),line=\\d+::a")
+    function rx(level)
+        workspace = get(ENV, "GITHUB_WORKSPACE", nothing)
+        file = @__FILE__
+        if workspace !== nothing
+            file = relpath(file, workspace)
+        end
+        return Regex("^::$level file=$(file),line=\\d+::a")
+    end
+    
     with_logger(GitHubActionsLogger()) do
         @test match(rx("debug"), (@capture_out @debug "a")) !== nothing
         @test match(rx("warning"), (@capture_out @warn "a")) !== nothing


### PR DESCRIPTION
In my experiments over in https://github.com/ericphanson/VisualStringDistances.jl/pull/14, this was the necessary trick to get inline annotations from error messages.

BTW: I don't know if `location` does anything here. It is not in the [`Logging.handle_message` docstring](https://docs.julialang.org/en/v1/stdlib/Logging/#Logging.handle_message) and it is not used by e.g. ConsoleLogger.