### PR TITLE
If a non-standard log-level is passed, don't hang

### DIFF
--- a/src/GitHubActions.jl
+++ b/src/GitHubActions.jl
@@ -247,7 +247,7 @@ function Logging.handle_message(
         elseif level === Error
             "error"
         else
-            "unknown"
+            "notice"
         end
         command(cmd, (file=file, line=line), message)
     end

--- a/src/GitHubActions.jl
+++ b/src/GitHubActions.jl
@@ -246,6 +246,8 @@ function Logging.handle_message(
             "warning"
         elseif level === Error
             "error"
+        else
+            "unknown"
         end
         command(cmd, (file=file, line=line), message)
     end


### PR DESCRIPTION
In HTTP.jl 1.0, we introduced the use of the verbose logging macros from LoggingExtras.jl. They currently work by modifying the log level like `@infov 1 msg` -> `@logmsg (Info - 1) msg`, resulting in non-standard log levels. In the conditional branches for the GitHubActionsLogger, it failed to account for non-standard levels, which resulted in the "hanging" behavior reported in https://github.com/JuliaWeb/HTTP.jl/issues/921. I don't know why it hangs, but adding this "unknown" branch makes everything work as expected.