### PR TITLE
Respect LogLevel of GHA by default

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GitHubActions"
 uuid = "6b79fd1a-b13a-48ab-b6b0-aaee1fee41df"
 authors = ["Chris de Graaf <me@cdg.dev> and contributors"]
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

--- a/src/GitHubActions.jl
+++ b/src/GitHubActions.jl
@@ -226,7 +226,13 @@ struct GitHubActionsLogger <: AbstractLogger
 end
 
 function get_gha_level()
-    is_debug = something(tryparse(Bool, get(ENV, "RUNNER_DEBUG", "false")), false)
+    env_str = get(ENV, "RUNNER_DEBUG", "false")
+    # `tryparse(Bool, "1")` does not work on Julia 1.0, so we special-case that value
+    # (which is the only documented value for `RUNNER_DEBUG`, so any other case should be
+    # due to the user setting it manually somehow).
+    env_str == "1" && return DEBUG
+    # Fallback for all other values:
+    is_debug = something(tryparse(Bool, env_str), false)
     return is_debug ? Debug : Info
 end
 

--- a/src/GitHubActions.jl
+++ b/src/GitHubActions.jl
@@ -18,7 +18,7 @@ export
     set_secret,
     start_group
 
-using Logging: Logging, AbstractLogger, Debug, Info, Warn, Error
+using Logging: Logging, AbstractLogger, LogLevel, Debug, Info, Warn, Error
 
 using JSON: json
 
@@ -213,14 +213,27 @@ function set_failed(msg)
 end
 
 """
-    GitHubActionsLogger()
+    GitHubActionsLogger(level)
 
 A logger that prints to standard output in the format expected by GitHub Actions.
+
+By default, GitHubActionsLogger inspects the
+[`RUNNER_DEBUG` environment variable](https://docs.github.com/en/actions/learn-github-actions/variables)
+to match the log-level to that set in GitHub Actions.
 """
-struct GitHubActionsLogger <: AbstractLogger end
+struct GitHubActionsLogger <: AbstractLogger
+    level::LogLevel
+end
+
+function get_gha_level()
+    is_debug = something(tryparse(Bool, get(ENV, "RUNNER_DEBUG", "false")), false)
+    return is_debug ? Debug : Info
+end
+
+GitHubActionsLogger() = GitHubActionsLogger(get_gha_level())
 
 Logging.catch_exceptions(::GitHubActionsLogger) = true
-Logging.min_enabled_level(::GitHubActionsLogger) = Debug
+Logging.min_enabled_level(logger::GitHubActionsLogger) = logger.level
 Logging.shouldlog(::GitHubActionsLogger, args...) = true
 
 function Logging.handle_message(
@@ -229,7 +242,7 @@ function Logging.handle_message(
     location=nothing, kwargs...,
 )
     file, line = something(location, (file, line))
-    
+
     workspace = get(ENV, "GITHUB_WORKSPACE", nothing)
     if workspace !== nothing
         # In order for inline annotations to work correctly:

--- a/src/GitHubActions.jl
+++ b/src/GitHubActions.jl
@@ -230,7 +230,7 @@ function get_gha_level()
     # `tryparse(Bool, "1")` does not work on Julia 1.0, so we special-case that value
     # (which is the only documented value for `RUNNER_DEBUG`, so any other case should be
     # due to the user setting it manually somehow).
-    env_str == "1" && return DEBUG
+    env_str == "1" && return Debug
     # Fallback for all other values:
     is_debug = something(tryparse(Bool, env_str), false)
     return is_debug ? Debug : Info

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -130,13 +130,13 @@ const GHA = GitHubActions
     @testset "get_gha_level" begin
         for val in ("1", "true")
             withenv("RUNNER_DEBUG" => val) do
-                GHA.get_gha_level() === Logging.Debug
+                @test GHA.get_gha_level() === Logging.Debug
             end
         end
 
-        for val in ("0", "false", "", nothing)
+        for val in ("0", "false", "", nothing, "garbage")
             withenv("RUNNER_DEBUG" => val) do
-                GHA.get_gha_level() === Logging.Info
+                @test GHA.get_gha_level() === Logging.Info
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Logging: with_logger
+using Logging: Logging, with_logger
 using Test: @test, @testset, @test_throws
 
 using GitHubActions
@@ -110,16 +110,34 @@ const GHA = GitHubActions
         return Regex("^::$level file=$(file),line=\\d+::a")
     end
 
-    with_logger(GitHubActionsLogger()) do
+    with_logger(GitHubActionsLogger(Logging.Debug)) do
         @test match(rx("debug"), (@capture_out @debug "a")) !== nothing
         @test match(rx("warning"), (@capture_out @warn "a")) !== nothing
         @test match(rx("error"), (@capture_out @error "a")) !== nothing
         @test (@capture_out @info "a") == "a\n"
 
-        @test (@capture_out @info "a" b=1 c=2 d=Text("e\nf")) == "a\n  b = 1\n  c = 2\n  d = \n    e\n    f\n"
-        @test endswith((@capture_out @warn "a" b=1 c=2), "::a%0A  b = 1%0A  c = 2\n")
+        @test (@capture_out @info "a" b = 1 c = 2 d = Text("e\nf")) == "a\n  b = 1\n  c = 2\n  d = \n    e\n    f\n"
+        @test endswith((@capture_out @warn "a" b = 1 c = 2), "::a%0A  b = 1%0A  c = 2\n")
 
         expected = "::warning file=test/bar,line=1::foo\n"
-        @test (@capture_out @warn "foo" location=("bar", 1)) == expected
+        @test (@capture_out @warn "foo" location = ("bar", 1)) == expected
+    end
+
+    with_logger(GitHubActionsLogger(Logging.Info)) do
+        @test match(rx("debug"), (@capture_out @debug "a")) === nothing
+    end
+
+    @testset "get_gha_level" begin
+        for val in ("1", "true")
+            withenv("RUNNER_DEBUG" => val) do
+                GHA.get_gha_level() === Logging.Debug
+            end
+        end
+
+        for val in ("0", "false", "", nothing)
+            withenv("RUNNER_DEBUG" => val) do
+                GHA.get_gha_level() === Logging.Info
+            end
+        end
     end
 end


### PR DESCRIPTION
I think this should workaround the issue in https://github.com/julia-actions/julia-docdeploy/issues/31, if I am correct in that the issue is super verbose debug logging

(this should be squash-merged due to messy commit history)