### PR TITLE
Widen JSON.jl compat to support both 0.21 and 1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v5
         env:
           cache-name: cache-artifacts
         with:
@@ -32,8 +32,8 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
         continue-on-error: ${{ matrix.version == 'nightly' }}
   docs:
     permissions:
@@ -41,8 +41,8 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
       - run: |

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GitHubActions"
 uuid = "6b79fd1a-b13a-48ab-b6b0-aaee1fee41df"
 authors = ["Chris de Graaf <me@cdg.dev> and contributors"]
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [compat]
-JSON = "0.21"
+JSON = "0.21, 1"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
## Summary

- Widens the JSON.jl compat bound from `"0.21"` to `"0.21, 1"` so users on either version aren't locked out
- No source code changes needed — `json(x)` behaves identically in both versions for all types used by this package

## Testing

Verified that all tests produce the same results (57 pass, 1 pre-existing fail unrelated to JSON.jl) on both:
- JSON.jl v0.21.4
- JSON.jl v1.4.0

Spot-checked serialization output for all types used by the package (tuples, arrays, strings, numbers, nothing) — identical across versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)